### PR TITLE
Feature/webhook enhancements

### DIFF
--- a/config/clickup-api.php
+++ b/config/clickup-api.php
@@ -53,6 +53,57 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTTP Client Timeouts
+    |--------------------------------------------------------------------------
+    |
+    | Hard limits applied to every outbound ClickUp request so a hung connection
+    | can never block a queue worker (or a web request) indefinitely. Values are
+    | in seconds.
+    |
+    */
+
+    'http' => [
+        'timeout'         => (int) env('MINDTWO_CLICKUP_HTTP_TIMEOUT', 10),
+        'connect_timeout' => (int) env('MINDTWO_CLICKUP_HTTP_CONNECT_TIMEOUT', 5),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook Delivery Retention
+    |--------------------------------------------------------------------------
+    |
+    | Number of days webhook delivery records are kept before Laravel's
+    | model:prune command removes them. Prevents the deliveries table from
+    | growing without bound.
+    |
+    */
+
+    'deliveries' => [
+        'retention_days' => (int) env('MINDTWO_CLICKUP_DELIVERY_RETENTION_DAYS', 30),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scheduled Maintenance
+    |--------------------------------------------------------------------------
+    |
+    | Opt-in recurring maintenance the package registers on the application's
+    | scheduler. All flags default to false so consuming apps keep full control
+    | and nothing runs unless explicitly enabled.
+    |
+    */
+
+    'schedule' => [
+        // Run CheckWebhookHealth (sync health + optional auto-restore) on a cadence.
+        'health_check' => (bool) env('MINDTWO_CLICKUP_SCHEDULE_HEALTH_CHECK', false),
+        // Reactivate failing/suspended webhooks via clickup:webhook-recover --all.
+        'auto_recover' => (bool) env('MINDTWO_CLICKUP_SCHEDULE_AUTO_RECOVER', false),
+        // Prune old webhook delivery records via model:prune.
+        'prune_deliveries' => (bool) env('MINDTWO_CLICKUP_SCHEDULE_PRUNE_DELIVERIES', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | ClickUp Mappings
     |--------------------------------------------------------------------------
     |
@@ -107,6 +158,12 @@ return [
             'taskStatusUpdated',
             'taskDeleted',
         ],
+
+        // When true, CheckWebhookHealth re-asserts the required_events coverage
+        // for every target it already manages (recreating a dropped taskDeleted
+        // webhook, reactivating a suspended one). Opt-in: defaults to off so the
+        // health check only syncs status unless explicitly enabled.
+        'auto_restore' => (bool) env('MINDTWO_CLICKUP_WEBHOOK_AUTO_RESTORE', false),
     ],
 
     /*

--- a/config/clickup-api.php
+++ b/config/clickup-api.php
@@ -96,6 +96,17 @@ return [
 
         // Middleware to apply to the webhook route
         'middleware' => ['api'],
+
+        // Event types that must always have an active webhook registered.
+        // Webhooks::ensureManaged() uses this as the baseline coverage so a
+        // dropped or suspended required webhook (e.g. taskDeleted) is restored
+        // instead of silently leaving the application blind to those events.
+        'required_events' => [
+            'taskCreated',
+            'taskUpdated',
+            'taskStatusUpdated',
+            'taskDeleted',
+        ],
     ],
 
     /*

--- a/database/migrations/2026_05_29_120000_add_recovery_stats_to_clickup_webhooks_table.php
+++ b/database/migrations/2026_05_29_120000_add_recovery_stats_to_clickup_webhooks_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('clickup_webhooks', function (Blueprint $table) {
+            $table->integer('deliveries_since_recovery')
+                ->default(0)
+                ->after('total_deliveries');
+            $table->integer('failed_deliveries_since_recovery')
+                ->default(0)
+                ->after('failed_deliveries');
+            $table->integer('recovery_count')
+                ->default(0)
+                ->after('failed_deliveries_since_recovery');
+            $table->timestamp('recovered_at')
+                ->nullable()
+                ->after('recovery_count');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('clickup_webhooks', function (Blueprint $table) {
+            $table->dropColumn([
+                'deliveries_since_recovery',
+                'failed_deliveries_since_recovery',
+                'recovery_count',
+                'recovered_at',
+            ]);
+        });
+    }
+};

--- a/src/ClickUpApiServiceProvider.php
+++ b/src/ClickUpApiServiceProvider.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Mindtwo\LaravelClickUpApi;
 
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
 use Mindtwo\LaravelClickUpApi\Commands\ListCustomFieldsCommand;
 use Mindtwo\LaravelClickUpApi\Commands\RecoverWebhookCommand;
+use Mindtwo\LaravelClickUpApi\Commands\WebhookHealthCommand;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\Attachment;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\AuthorizedUser;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\CustomField;
@@ -25,6 +27,7 @@ use Mindtwo\LaravelClickUpApi\Http\Endpoints\TaskList;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\Views;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\Webhooks;
 use Mindtwo\LaravelClickUpApi\Http\Endpoints\Workspaces;
+use Mindtwo\LaravelClickUpApi\Models\ClickUpWebhookDelivery;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -41,6 +44,7 @@ class ClickUpApiServiceProvider extends PackageServiceProvider
             ->name('laravel-clickup-api')
             ->hasCommand(ListCustomFieldsCommand::class)
             ->hasCommand(RecoverWebhookCommand::class)
+            ->hasCommand(WebhookHealthCommand::class)
             ->hasConfigFile();
     }
 
@@ -90,10 +94,39 @@ class ClickUpApiServiceProvider extends PackageServiceProvider
         // Register event logging listener
         $this->registerEventLogging();
 
+        // Register opt-in scheduled maintenance
+        $this->registerSchedule();
+
         // Publish migrations
         $this->publishes([
             __DIR__.'/../database/migrations' => database_path('migrations'),
         ], 'clickup-api-migrations');
+    }
+
+    /**
+     * Register opt-in scheduled maintenance tasks.
+     *
+     * Every task is gated behind a `clickup-api.schedule.*` flag that defaults to
+     * false, so nothing runs unless the consuming application opts in.
+     */
+    protected function registerSchedule(): void
+    {
+        $this->app->booted(function (): void {
+            /** @var Schedule $schedule */
+            $schedule = $this->app->make(Schedule::class);
+
+            if (config('clickup-api.schedule.health_check', false)) {
+                $schedule->command('clickup:webhook-health')->everyThirtyMinutes();
+            }
+
+            if (config('clickup-api.schedule.auto_recover', false)) {
+                $schedule->command('clickup:webhook-recover', ['--all' => true])->hourly();
+            }
+
+            if (config('clickup-api.schedule.prune_deliveries', false)) {
+                $schedule->command('model:prune', ['--model' => [ClickUpWebhookDelivery::class]])->daily();
+            }
+        });
     }
 
     /**

--- a/src/ClickUpClient.php
+++ b/src/ClickUpClient.php
@@ -31,6 +31,8 @@ class ClickUpClient
         protected string $baseUrl = 'https://api.clickup.com/api/v2'
     ) {
         $this->client = Http::baseUrl($this->baseUrl)
+            ->timeout((int) config('clickup-api.http.timeout', 10))
+            ->connectTimeout((int) config('clickup-api.http.connect_timeout', 5))
             ->withHeaders([
                 'Authorization' => $this->apiKey,
                 'Accept'        => 'application/json',

--- a/src/Commands/RecoverWebhookCommand.php
+++ b/src/Commands/RecoverWebhookCommand.php
@@ -131,11 +131,7 @@ class RecoverWebhookCommand extends Command
             ]);
 
             if ($response->status() === 200) {
-                $webhook->update([
-                    'health_status' => WebhookHealthStatus::ACTIVE,
-                    'is_active'     => true,
-                    'fail_count'    => 0,
-                ]);
+                $webhook->markRecovered();
 
                 $this->info("  ✓ Successfully recovered webhook {$webhook->clickup_webhook_id}");
 

--- a/src/Commands/RecoverWebhookCommand.php
+++ b/src/Commands/RecoverWebhookCommand.php
@@ -147,6 +147,11 @@ class RecoverWebhookCommand extends Command
                 return true;
             }
 
+            // ClickUp has deleted the webhook upstream - it cannot be updated, only recreated.
+            if ($response->status() === 404) {
+                return $this->recreateWebhook($webhook, $webhooksEndpoint);
+            }
+
             /* @var array<string, mixed> $responseJson */
             $responseJson = $response->json();
             if (is_array($responseJson)) {
@@ -162,6 +167,65 @@ class RecoverWebhookCommand extends Command
             $this->error("  ✗ Error recovering webhook: {$e->getMessage()}");
 
             Log::error('Webhook recovery command failed', [
+                'webhook_id' => $webhook->clickup_webhook_id,
+                'error'      => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Recreate a webhook that ClickUp has deleted upstream, preserving its target scoping.
+     */
+    protected function recreateWebhook(ClickUpWebhook $webhook, Webhooks $webhooksEndpoint): bool
+    {
+        $workspaceId = config('clickup-api.default_workspace_id');
+
+        if (empty($workspaceId)) {
+            $this->error('  ✗ Cannot recreate webhook: no default workspace configured.');
+
+            return false;
+        }
+
+        $data = [
+            'endpoint' => $webhook->endpoint,
+            'events'   => explode(',', $webhook->event),
+        ];
+
+        // Re-apply the original target scoping so the new webhook watches the same resource.
+        $targetKey = match ($webhook->target_type) {
+            'space'  => 'space_id',
+            'folder' => 'folder_id',
+            'list'   => 'list_id',
+            'task'   => 'task_id',
+            default  => null,
+        };
+
+        if ($targetKey !== null) {
+            $data[$targetKey] = $webhook->target_id;
+        }
+
+        try {
+            $newWebhook = $webhooksEndpoint->createManaged($workspaceId, $data);
+
+            // Remove the stale row that pointed at the now-deleted ClickUp webhook.
+            $oldClickUpId = $webhook->clickup_webhook_id;
+            $webhook->delete();
+
+            $this->info("  ✓ Recreated webhook (old {$oldClickUpId} -> new {$newWebhook->clickup_webhook_id})");
+
+            Log::info('Webhook recreated via command after upstream deletion', [
+                'old_webhook_id' => $oldClickUpId,
+                'new_webhook_id' => $newWebhook->clickup_webhook_id,
+                'endpoint'       => $newWebhook->endpoint,
+            ]);
+
+            return true;
+        } catch (Throwable $e) {
+            $this->error("  ✗ Failed to recreate webhook: {$e->getMessage()}");
+
+            Log::error('Webhook recreation command failed', [
                 'webhook_id' => $webhook->clickup_webhook_id,
                 'error'      => $e->getMessage(),
             ]);

--- a/src/Commands/WebhookHealthCommand.php
+++ b/src/Commands/WebhookHealthCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mindtwo\LaravelClickUpApi\Commands;
+
+use Illuminate\Console\Command;
+use Mindtwo\LaravelClickUpApi\Jobs\CheckWebhookHealth;
+
+class WebhookHealthCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clickup:webhook-health
+                            {--sync : Run the health check inline instead of dispatching to the queue}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync ClickUp webhook health and, when auto-restore is enabled, recreate missing required webhooks';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if ($this->option('sync')) {
+            CheckWebhookHealth::dispatchSync();
+            $this->info('Webhook health check completed (sync).');
+
+            return self::SUCCESS;
+        }
+
+        CheckWebhookHealth::dispatch();
+        $this->info('Webhook health check dispatched to the queue.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Exceptions/ClickUpApiCallFailedException.php
+++ b/src/Exceptions/ClickUpApiCallFailedException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mindtwo\LaravelClickUpApi\Exceptions;
+
+use Illuminate\Http\Client\Response;
+use RuntimeException;
+
+class ClickUpApiCallFailedException extends RuntimeException
+{
+    /**
+     * @param array<string, mixed> $response
+     */
+    public function __construct(
+        public readonly string $endpoint,
+        public readonly string $method,
+        public readonly int $statusCode,
+        public readonly array $response = [],
+    ) {
+        parent::__construct(sprintf(
+            'ClickUp API call %s %s failed with status %d: %s',
+            $method,
+            $endpoint,
+            $statusCode,
+            $response['err'] ?? 'Unknown error',
+        ));
+    }
+
+    /**
+     * Build the exception from a received HTTP response.
+     */
+    public static function fromResponse(string $endpoint, string $method, Response $response): self
+    {
+        return new self($endpoint, $method, $response->status(), $response->json() ?? []);
+    }
+}

--- a/src/Http/Endpoints/Webhooks.php
+++ b/src/Http/Endpoints/Webhooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mindtwo\LaravelClickUpApi\Http\Endpoints;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Mindtwo\LaravelClickUpApi\ClickUpClient;
 use Mindtwo\LaravelClickUpApi\Enums\WebhookHealthStatus;
 use Mindtwo\LaravelClickUpApi\Http\LazyResponseProxy;
@@ -244,6 +245,160 @@ class Webhooks
         }
 
         return $synced;
+    }
+
+    /**
+     * Ensure the desired set of managed webhooks exists and is active in ClickUp.
+     *
+     * For every desired specification this guarantees an active webhook covering
+     * the given target and events by, in order of preference:
+     *   1. leaving an already-active matching webhook untouched,
+     *   2. reactivating a matching webhook that exists but is inactive,
+     *   3. recreating it when ClickUp no longer knows the webhook (update 404),
+     *   4. creating a brand-new webhook when none covers the target + events.
+     *
+     * This closes the gap where a required event-type webhook (e.g. taskDeleted)
+     * is silently dropped or suspended and never restored, which leaves the
+     * application blind to those events.
+     *
+     * @param int|string $workspaceId The workspace the webhooks belong to
+     * @param array<int, array<string, mixed>> $desired List of specs, each with an
+     *                                                  `events` array plus optional `endpoint`
+     *                                                  and a target key (space_id/folder_id/list_id/task_id)
+     *
+     * @return Collection<int, ClickUpWebhook> The ensured webhooks
+     */
+    public function ensureManaged(int|string $workspaceId, array $desired): Collection
+    {
+        $ensured = collect();
+
+        foreach ($desired as $spec) {
+            /** @var array<int, string> $events */
+            $events = array_values(array_unique($spec['events'] ?? []));
+
+            if (empty($events)) {
+                continue;
+            }
+
+            [$targetType, $targetId] = $this->determineTarget($workspaceId, $spec);
+
+            $existing = $this->findManagedWebhook($targetType, (string) $targetId, $events);
+
+            if ($existing && $existing->is_active && $existing->health_status === WebhookHealthStatus::ACTIVE) {
+                $ensured->push($existing);
+
+                continue;
+            }
+
+            if ($existing) {
+                $ensured->push($this->reactivateOrRecreate($workspaceId, $existing, $spec, $events));
+
+                continue;
+            }
+
+            Log::info('Creating missing managed ClickUp webhook', [
+                'target_type' => $targetType,
+                'target_id'   => (string) $targetId,
+                'events'      => $events,
+            ]);
+
+            $ensured->push($this->createManaged($workspaceId, $spec));
+        }
+
+        return $ensured;
+    }
+
+    /**
+     * Find a managed webhook for the given target whose event list covers all desired events.
+     *
+     * @param array<int, string> $events
+     */
+    private function findManagedWebhook(string $targetType, string $targetId, array $events): ?ClickUpWebhook
+    {
+        /** @var ClickUpWebhook */
+        return ClickUpWebhook::query()
+            ->where('target_type', $targetType)
+            ->where('target_id', $targetId)
+            ->get()
+            ->first(function (ClickUpWebhook $webhook) use ($events): bool {
+                $covered = array_filter(array_map('trim', explode(',', (string) $webhook->event)));
+
+                // A wildcard webhook covers every event type.
+                if (in_array('*', $covered, true)) {
+                    return true;
+                }
+
+                return empty(array_diff($events, $covered));
+            });
+    }
+
+    /**
+     * Reactivate an inactive webhook, or recreate it when ClickUp has dropped it.
+     *
+     * @param array<string, mixed> $spec
+     * @param array<int, string> $events
+     */
+    private function reactivateOrRecreate(int|string $workspaceId, ClickUpWebhook $webhook, array $spec, array $events): ClickUpWebhook
+    {
+        $endpoint = $spec['endpoint'] ?? $webhook->endpoint ?? $this->defaultEndpoint();
+
+        // A managed row without an upstream ID was never really registered - recreate it.
+        if (empty($webhook->clickup_webhook_id)) {
+            $webhook->delete();
+
+            return $this->createManaged($workspaceId, $spec);
+        }
+
+        $response = $this->update($webhook->clickup_webhook_id, [
+            'endpoint' => $endpoint,
+            'events'   => $events,
+            'status'   => 'active',
+        ]);
+
+        if ($response->status() === 200) {
+            $webhook->update([
+                'endpoint'      => $endpoint,
+                'event'         => implode(',', $events),
+                'health_status' => WebhookHealthStatus::ACTIVE,
+                'is_active'     => true,
+                'fail_count'    => 0,
+            ]);
+
+            Log::info('Reactivated managed ClickUp webhook', [
+                'webhook_id' => $webhook->clickup_webhook_id,
+                'events'     => $events,
+            ]);
+
+            $webhook->refresh();
+
+            return $webhook;
+        }
+
+        if ($response->status() === 404) {
+            // The webhook no longer exists in ClickUp - drop the stale row and recreate it.
+            Log::warning('Managed ClickUp webhook missing upstream, recreating', [
+                'webhook_id' => $webhook->clickup_webhook_id,
+                'events'     => $events,
+            ]);
+
+            $webhook->delete();
+
+            return $this->createManaged($workspaceId, $spec);
+        }
+
+        $error = $response->json()['err'] ?? 'Unknown error';
+        throw new RuntimeException("ClickUp Api call failed: {$error}");
+    }
+
+    /**
+     * Build the default webhook endpoint URL from configuration.
+     */
+    private function defaultEndpoint(): string
+    {
+        $appUrl = rtrim((string) config('app.url'), '/');
+        $webhookPath = config('clickup-api.webhook.path', '/webhooks/clickup');
+
+        return $appUrl.$webhookPath;
     }
 
     /**

--- a/src/Http/Endpoints/Webhooks.php
+++ b/src/Http/Endpoints/Webhooks.php
@@ -315,7 +315,7 @@ class Webhooks
      */
     private function findManagedWebhook(string $targetType, string $targetId, array $events): ?ClickUpWebhook
     {
-        /** @var ClickUpWebhook */
+        /** @var ClickUpWebhook|null */
         return ClickUpWebhook::query()
             ->where('target_type', $targetType)
             ->where('target_id', $targetId)

--- a/src/Http/LazyResponseProxy.php
+++ b/src/Http/LazyResponseProxy.php
@@ -7,6 +7,7 @@ namespace Mindtwo\LaravelClickUpApi\Http;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response;
 use Mindtwo\LaravelClickUpApi\ClickUpClient;
+use Mindtwo\LaravelClickUpApi\Events\ClickUpApiCallCompleted;
 use Mindtwo\LaravelClickUpApi\Jobs\ClickUpApiCallJob;
 use RuntimeException;
 
@@ -120,6 +121,16 @@ class LazyResponseProxy
         };
 
         $this->executed = true;
+
+        // Mirror the queued ClickUpApiCallJob so synchronous and queued execution
+        // emit the same lifecycle event (success AND failure).
+        ClickUpApiCallCompleted::dispatch(
+            $this->endpoint,
+            $this->method,
+            $this->response->json() ?? [],
+            $this->response->status(),
+            $this->response->successful(),
+        );
 
         return $this->response;
     }

--- a/src/Jobs/CheckWebhookHealth.php
+++ b/src/Jobs/CheckWebhookHealth.php
@@ -168,6 +168,19 @@ class CheckWebhookHealth implements ShouldQueue
                 'status'     => $newStatus->value,
                 'fail_count' => $webhook->fail_count,
             ]);
+
+            return;
+        }
+
+        // ClickUp reactivated a previously failing/suspended webhook on its own:
+        // treat it as a recovery so the recovery-relative counters reset too.
+        if ($previousStatus?->needsRecovery() && $newStatus === WebhookHealthStatus::ACTIVE) {
+            $webhook->markRecovered();
+
+            Log::info('Webhook recovered via ClickUp-side reactivation', [
+                'webhook_id'     => $webhook->clickup_webhook_id,
+                'recovery_count' => $webhook->recovery_count,
+            ]);
         }
     }
 

--- a/src/Jobs/CheckWebhookHealth.php
+++ b/src/Jobs/CheckWebhookHealth.php
@@ -48,6 +48,12 @@ class CheckWebhookHealth implements ShouldQueue
 
             $this->checkWorkspaceWebhooks($workspaceId, $webhooksEndpoint);
 
+            // Opt-in: re-assert that every managed target still has all required
+            // event webhooks active, recreating any that were dropped/suspended.
+            if (config('clickup-api.webhook.auto_restore', false)) {
+                $this->ensureRequiredWebhooks($workspaceId, $webhooksEndpoint);
+            }
+
             Log::info('Webhook health check completed');
         } catch (Throwable $e) {
             Log::error('Webhook health check failed', [
@@ -163,6 +169,69 @@ class CheckWebhookHealth implements ShouldQueue
                 'fail_count' => $webhook->fail_count,
             ]);
         }
+    }
+
+    /**
+     * Re-assert required-event coverage for every target already managed locally.
+     *
+     * Uses the targets that already exist in the database (so no target guessing
+     * is needed) and lets Webhooks::ensureManaged() create/reactivate only what is
+     * missing. This restores e.g. a dropped taskDeleted webhook for a space that
+     * already has the other event webhooks.
+     */
+    protected function ensureRequiredWebhooks(int|string $workspaceId, Webhooks $webhooksEndpoint): void
+    {
+        /** @var array<int, string> $requiredEvents */
+        $requiredEvents = config('clickup-api.webhook.required_events', []);
+
+        if (empty($requiredEvents)) {
+            return;
+        }
+
+        $targets = ClickUpWebhook::query()
+            ->get()
+            ->groupBy(fn (ClickUpWebhook $webhook): string => $webhook->target_type.':'.$webhook->target_id);
+
+        foreach ($targets as $group) {
+            $sample = $group->first();
+
+            if (! $sample instanceof ClickUpWebhook) {
+                continue;
+            }
+
+            $webhooksEndpoint->ensureManaged($workspaceId, $this->buildDesiredSpecs($sample, $requiredEvents));
+        }
+    }
+
+    /**
+     * Build one ensureManaged spec per required event for the sample's target.
+     *
+     * @param array<int, string> $requiredEvents
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildDesiredSpecs(ClickUpWebhook $sample, array $requiredEvents): array
+    {
+        $targetKey = match ($sample->target_type) {
+            'space'  => 'space_id',
+            'folder' => 'folder_id',
+            'list'   => 'list_id',
+            'task'   => 'task_id',
+            default  => null,
+        };
+
+        return array_map(function (string $event) use ($sample, $targetKey): array {
+            $spec = [
+                'events'   => [$event],
+                'endpoint' => $sample->endpoint,
+            ];
+
+            if ($targetKey !== null) {
+                $spec[$targetKey] = $sample->target_id;
+            }
+
+            return $spec;
+        }, $requiredEvents);
     }
 
     /**

--- a/src/Jobs/ClickUpApiCallJob.php
+++ b/src/Jobs/ClickUpApiCallJob.php
@@ -12,15 +12,15 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\RateLimited;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use Mindtwo\LaravelClickUpApi\ClickUpClient;
 use Mindtwo\LaravelClickUpApi\Enums\EventSource;
 use Mindtwo\LaravelClickUpApi\Events\ClickUpApiCallCompleted;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskCreated;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskDeleted;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskUpdated;
-use Mindtwo\LaravelClickUpApi\Http\LazyResponseProxy;
-use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
+use Throwable;
 
 class ClickUpApiCallJob implements ShouldQueue
 {
@@ -36,9 +36,9 @@ class ClickUpApiCallJob implements ShouldQueue
     public int $tries = 5;
 
     /**
-     * The number of seconds to wait before retrying the job.
+     * The maximum number of seconds the job may run before timing out.
      */
-    public int $backoff = 30;
+    public int $timeout = 30;
 
     /**
      * @param array<string, mixed> $body
@@ -81,9 +81,9 @@ class ClickUpApiCallJob implements ShouldQueue
             default                => throw new \InvalidArgumentException("Unsupported HTTP method: {$this->method}"),
         };
 
-        $this->validateResponse($response);
-
-        // Dispatch event with response data
+        // Always notify listeners of the outcome (success AND failure). Emitting on
+        // failure is what lets consumers react to e.g. a 404 (deleted task) - the old
+        // code threw before dispatching, so failure events never fired.
         ClickUpApiCallCompleted::dispatch(
             $this->endpoint,
             $this->method,
@@ -92,8 +92,29 @@ class ClickUpApiCallJob implements ShouldQueue
             $response->successful(),
         );
 
-        // Dispatch task-specific events
-        $this->dispatchTaskEvents($response);
+        if ($response->successful()) {
+            $this->dispatchTaskEvents($response);
+
+            return;
+        }
+
+        $status = $response->status();
+
+        // Retry only transient failures (rate limiting / server errors), honoring
+        // ClickUp's Retry-After. Terminal 4xx (e.g. 404 deleted, 400 bad request)
+        // must NOT be retried - that was a source of pointless retry storms.
+        if (($status === 429 || $status >= 500) && $this->attempts() < $this->tries) {
+            $this->release($this->retryAfterSeconds($response));
+
+            return;
+        }
+
+        Log::warning('ClickUp API call failed (terminal)', [
+            'endpoint' => $this->endpoint,
+            'method'   => $this->method,
+            'status'   => $status,
+            'error'    => $response->json()['err'] ?? 'Unknown error',
+        ]);
     }
 
     /**
@@ -104,6 +125,57 @@ class ClickUpApiCallJob implements ShouldQueue
     public function middleware(): array
     {
         return [new RateLimited('clickup-api-jobs')];
+    }
+
+    /**
+     * Exponential backoff (seconds) between retry attempts.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [10, 30, 60, 120];
+    }
+
+    /**
+     * Handle a job that has ultimately failed (e.g. connection timeout with no
+     * HTTP response). The response-based path already emits a failure event for
+     * any received non-200; this covers the no-response case.
+     */
+    public function failed(?Throwable $e): void
+    {
+        ClickUpApiCallCompleted::dispatch(
+            $this->endpoint,
+            $this->method,
+            ['err' => $e?->getMessage() ?? 'ClickUp API job failed'],
+            0,
+            false,
+        );
+    }
+
+    /**
+     * Resolve how long to wait before retrying, honoring ClickUp rate-limit headers.
+     */
+    private function retryAfterSeconds(Response $response): int
+    {
+        $retryAfter = $response->header('Retry-After');
+
+        if (is_numeric($retryAfter)) {
+            return max(1, (int) $retryAfter);
+        }
+
+        // ClickUp exposes the reset moment as a UNIX timestamp.
+        $reset = $response->header('X-RateLimit-Reset');
+
+        if (is_numeric($reset)) {
+            $delta = (int) $reset - time();
+
+            if ($delta > 0) {
+                return $delta;
+            }
+        }
+
+        return 30;
     }
 
     /**
@@ -153,21 +225,6 @@ class ClickUpApiCallJob implements ShouldQueue
             );
 
             return;
-        }
-    }
-
-    /**
-     * Validate HTTP response status and throw a runtime exception on failure.
-     *
-     * **Warning:** This method will execute lazy responses, no job retrieval will be possible after calling this.
-     *
-     * @throws RuntimeException
-     */
-    private function validateResponse(Response|LazyResponseProxy $response): void
-    {
-        if ($response->status() !== 200) {
-            $error = $response->json()['err'] ?? 'Unknown error';
-            throw new RuntimeException("ClickUp Api call failed: {$error}");
         }
     }
 }

--- a/src/Jobs/ClickUpApiCallJob.php
+++ b/src/Jobs/ClickUpApiCallJob.php
@@ -19,6 +19,7 @@ use Mindtwo\LaravelClickUpApi\Events\ClickUpApiCallCompleted;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskCreated;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskDeleted;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskUpdated;
+use Mindtwo\LaravelClickUpApi\Exceptions\ClickUpApiCallFailedException;
 use Symfony\Component\HttpFoundation\Request;
 use Throwable;
 
@@ -115,6 +116,10 @@ class ClickUpApiCallJob implements ShouldQueue
             'status'   => $status,
             'error'    => $response->json()['err'] ?? 'Unknown error',
         ]);
+
+        // If we reach this point the failure is terminal: fail the job with a specialized
+        // exception so the failed-jobs store records the endpoint, method, status and error.
+        $this->fail(ClickUpApiCallFailedException::fromResponse($this->endpoint, $this->method, $response));
     }
 
     /**
@@ -144,6 +149,12 @@ class ClickUpApiCallJob implements ShouldQueue
      */
     public function failed(?Throwable $e): void
     {
+        // Terminal HTTP failures already emitted an accurate completion event in handle();
+        // re-dispatching here would duplicate it with a bogus statusCode 0.
+        if ($e instanceof ClickUpApiCallFailedException) {
+            return;
+        }
+
         ClickUpApiCallCompleted::dispatch(
             $this->endpoint,
             $this->method,

--- a/src/Models/ClickUpWebhook.php
+++ b/src/Models/ClickUpWebhook.php
@@ -25,12 +25,17 @@ use Mindtwo\LaravelClickUpApi\Enums\WebhookHealthStatus;
  * @property Carbon|null $last_triggered_at
  * @property int $total_deliveries
  * @property int $failed_deliveries
+ * @property int $deliveries_since_recovery
+ * @property int $failed_deliveries_since_recovery
+ * @property int $recovery_count
+ * @property Carbon|null $recovered_at
  * @property array<string, mixed>|null $last_error
  * @property bool $is_active
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  * @property-read float $failure_rate
+ * @property-read float $failure_rate_since_recovery
  */
 class ClickUpWebhook extends Model
 {
@@ -52,19 +57,27 @@ class ClickUpWebhook extends Model
         'last_triggered_at',
         'total_deliveries',
         'failed_deliveries',
+        'deliveries_since_recovery',
+        'failed_deliveries_since_recovery',
+        'recovery_count',
+        'recovered_at',
         'last_error',
         'is_active',
     ];
 
     protected $casts = [
-        'last_triggered_at' => 'datetime',
-        'health_checked_at' => 'datetime',
-        'health_status'     => WebhookHealthStatus::class,
-        'last_error'        => 'array',
-        'is_active'         => 'boolean',
-        'total_deliveries'  => 'integer',
-        'failed_deliveries' => 'integer',
-        'fail_count'        => 'integer',
+        'last_triggered_at'                => 'datetime',
+        'health_checked_at'                => 'datetime',
+        'recovered_at'                     => 'datetime',
+        'health_status'                    => WebhookHealthStatus::class,
+        'last_error'                       => 'array',
+        'is_active'                        => 'boolean',
+        'total_deliveries'                 => 'integer',
+        'failed_deliveries'                => 'integer',
+        'deliveries_since_recovery'        => 'integer',
+        'failed_deliveries_since_recovery' => 'integer',
+        'recovery_count'                   => 'integer',
+        'fail_count'                       => 'integer',
     ];
 
     /**
@@ -81,6 +94,7 @@ class ClickUpWebhook extends Model
     public function recordDelivery(): void
     {
         $this->increment('total_deliveries');
+        $this->increment('deliveries_since_recovery');
         $this->update(['last_triggered_at' => now()]);
     }
 
@@ -90,11 +104,33 @@ class ClickUpWebhook extends Model
     public function recordFailure(string $error): void
     {
         $this->increment('failed_deliveries');
+        $this->increment('failed_deliveries_since_recovery');
         $this->update([
             'last_error' => [
                 'error'     => $error,
                 'timestamp' => now()->toIso8601String(),
             ],
+        ]);
+    }
+
+    /**
+     * Mark this webhook as recovered, restoring it to a healthy state and
+     * resetting the recovery-relative counters while preserving lifetime totals.
+     *
+     * Called both by the manual recovery command and by the health check job
+     * when ClickUp reports a previously failing/suspended webhook as active again.
+     */
+    public function markRecovered(): void
+    {
+        $this->update([
+            'health_status'                    => WebhookHealthStatus::ACTIVE,
+            'is_active'                        => true,
+            'fail_count'                       => 0,
+            'deliveries_since_recovery'        => 0,
+            'failed_deliveries_since_recovery' => 0,
+            'last_error'                       => null,
+            'recovered_at'                     => now(),
+            'recovery_count'                   => $this->recovery_count + 1,
         ]);
     }
 
@@ -108,6 +144,18 @@ class ClickUpWebhook extends Model
         }
 
         return ($this->failed_deliveries / $this->total_deliveries) * 100;
+    }
+
+    /**
+     * Get the failure rate of this webhook since its last recovery.
+     */
+    public function getFailureRateSinceRecoveryAttribute(): float
+    {
+        if ($this->deliveries_since_recovery === 0) {
+            return 0.0;
+        }
+
+        return ($this->failed_deliveries_since_recovery / $this->deliveries_since_recovery) * 100;
     }
 
     /**

--- a/src/Models/ClickUpWebhookDelivery.php
+++ b/src/Models/ClickUpWebhookDelivery.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Mindtwo\LaravelClickUpApi\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -22,6 +24,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class ClickUpWebhookDelivery extends Model
 {
+    use Prunable;
+
     protected $table = 'clickup_webhook_deliveries';
 
     protected $fillable = [
@@ -38,6 +42,19 @@ class ClickUpWebhookDelivery extends Model
         'payload'            => 'array',
         'processing_time_ms' => 'integer',
     ];
+
+    /**
+     * Records older than the configured retention window are pruned by
+     * Laravel's model:prune command, preventing unbounded table growth.
+     *
+     * @return Builder<ClickUpWebhookDelivery>
+     */
+    public function prunable(): Builder
+    {
+        $days = (int) config('clickup-api.deliveries.retention_days', 30);
+
+        return static::where('created_at', '<=', now()->subDays($days));
+    }
 
     /**
      * @return BelongsTo<ClickUpWebhook, $this>

--- a/tests/Feature/EnsureManagedWebhooksTest.php
+++ b/tests/Feature/EnsureManagedWebhooksTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Mindtwo\LaravelClickUpApi\ClickUpClient;
+use Mindtwo\LaravelClickUpApi\Enums\WebhookHealthStatus;
+use Mindtwo\LaravelClickUpApi\Http\Endpoints\Webhooks;
+use Mindtwo\LaravelClickUpApi\Http\LazyResponseProxy;
+use Mindtwo\LaravelClickUpApi\Models\ClickUpWebhook;
+
+uses()->group('ensure-managed-webhooks');
+
+beforeEach(function () {
+    foreach (File::allFiles(__DIR__.'/../../database/migrations') as $migration) {
+        (include $migration->getRealPath())->up();
+    }
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('creates a missing required webhook', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    $webhooks->shouldReceive('create')
+        ->once()
+        ->andReturn(ensureManagedResponse(200, [
+            'webhook' => ['id' => 'wh_new', 'endpoint' => 'https://app.test/webhooks/clickup'],
+        ]));
+
+    $result = $webhooks->ensureManaged('ws_1', [
+        ['events' => ['taskDeleted'], 'space_id' => 's1', 'endpoint' => 'https://app.test/webhooks/clickup'],
+    ]);
+
+    expect($result)->toHaveCount(1);
+
+    $row = ClickUpWebhook::where('clickup_webhook_id', 'wh_new')->first();
+
+    expect($row)->not->toBeNull()
+        ->and($row->event)->toBe('taskDeleted')
+        ->and($row->target_type)->toBe('space')
+        ->and($row->target_id)->toBe('s1')
+        ->and($row->is_active)->toBeTrue();
+});
+
+test('leaves an already active matching webhook untouched', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    $webhooks->shouldReceive('create')->never();
+    $webhooks->shouldReceive('update')->never();
+
+    ensureManagedWebhook('wh_active', 'taskDeleted', 's1', active: true);
+
+    $result = $webhooks->ensureManaged('ws_1', [
+        ['events' => ['taskDeleted'], 'space_id' => 's1'],
+    ]);
+
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->clickup_webhook_id)->toBe('wh_active')
+        ->and(ClickUpWebhook::count())->toBe(1);
+});
+
+test('treats a wildcard webhook as covering the event', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    $webhooks->shouldReceive('create')->never();
+    $webhooks->shouldReceive('update')->never();
+
+    ensureManagedWebhook('wh_wild', '*', 's1', active: true);
+
+    $result = $webhooks->ensureManaged('ws_1', [
+        ['events' => ['taskDeleted'], 'space_id' => 's1'],
+    ]);
+
+    expect($result->first()->clickup_webhook_id)->toBe('wh_wild');
+});
+
+test('reactivates an inactive matching webhook', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    $existing = ensureManagedWebhook(
+        'wh_1',
+        'taskDeleted',
+        's1',
+        active: false,
+        status: WebhookHealthStatus::FAILING,
+        failCount: 60,
+    );
+
+    $webhooks->shouldReceive('update')
+        ->once()
+        ->with('wh_1', Mockery::on(fn ($data) => $data['status'] === 'active' && $data['events'] === ['taskDeleted']))
+        ->andReturn(ensureManagedResponse(200));
+    $webhooks->shouldReceive('create')->never();
+
+    $webhooks->ensureManaged('ws_1', [
+        ['events' => ['taskDeleted'], 'space_id' => 's1', 'endpoint' => 'https://app.test/webhooks/clickup'],
+    ]);
+
+    $existing->refresh();
+
+    expect($existing->is_active)->toBeTrue()
+        ->and($existing->health_status)->toBe(WebhookHealthStatus::ACTIVE)
+        ->and($existing->fail_count)->toBe(0);
+});
+
+test('recreates a webhook that no longer exists in clickup', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    ensureManagedWebhook('wh_gone', 'taskDeleted', 's1', active: false, status: WebhookHealthStatus::SUSPENDED);
+
+    $webhooks->shouldReceive('update')
+        ->once()
+        ->with('wh_gone', Mockery::any())
+        ->andReturn(ensureManagedResponse(404, ['err' => 'Webhook not found']));
+
+    $webhooks->shouldReceive('create')
+        ->once()
+        ->andReturn(ensureManagedResponse(200, [
+            'webhook' => ['id' => 'wh_new', 'endpoint' => 'https://app.test/webhooks/clickup'],
+        ]));
+
+    $result = $webhooks->ensureManaged('ws_1', [
+        ['events' => ['taskDeleted'], 'space_id' => 's1', 'endpoint' => 'https://app.test/webhooks/clickup'],
+    ]);
+
+    expect($result->first()->clickup_webhook_id)->toBe('wh_new')
+        ->and(ClickUpWebhook::where('clickup_webhook_id', 'wh_gone')->exists())->toBeFalse()
+        ->and(ClickUpWebhook::where('clickup_webhook_id', 'wh_gone')->withTrashed()->exists())->toBeTrue()
+        ->and(ClickUpWebhook::where('clickup_webhook_id', 'wh_new')->exists())->toBeTrue();
+});
+
+test('skips specs without events', function () {
+    $webhooks = ensureManagedWebhooksMock();
+
+    $webhooks->shouldReceive('create')->never();
+    $webhooks->shouldReceive('update')->never();
+
+    $result = $webhooks->ensureManaged('ws_1', [['events' => []]]);
+
+    expect($result)->toHaveCount(0)
+        ->and(ClickUpWebhook::count())->toBe(0);
+});
+
+/**
+ * Build a partial mock of the Webhooks endpoint with a stubbed ClickUp client,
+ * so the raw create()/update() HTTP calls can be mocked while the managed
+ * reconcile logic runs for real.
+ *
+ * @return Webhooks&Mockery\MockInterface
+ */
+function ensureManagedWebhooksMock(): Webhooks
+{
+    $api = Mockery::mock(ClickUpClient::class);
+
+    return Mockery::mock(Webhooks::class, [$api])->makePartial();
+}
+
+/**
+ * Build a mocked LazyResponseProxy with the given status and JSON body.
+ */
+function ensureManagedResponse(int $status, array $json = []): LazyResponseProxy
+{
+    $response = Mockery::mock(LazyResponseProxy::class);
+    $response->shouldReceive('status')->andReturn($status);
+    $response->shouldReceive('json')->andReturn($json);
+
+    return $response;
+}
+
+/**
+ * Create a space-scoped webhook row for ensureManaged tests.
+ */
+function ensureManagedWebhook(
+    string $clickUpWebhookId,
+    string $event,
+    string $spaceId,
+    bool $active,
+    WebhookHealthStatus $status = WebhookHealthStatus::ACTIVE,
+    int $failCount = 0,
+): ClickUpWebhook {
+    return ClickUpWebhook::create([
+        'clickup_webhook_id' => $clickUpWebhookId,
+        'endpoint'           => 'https://app.test/webhooks/clickup',
+        'event'              => $event,
+        'target_type'        => 'space',
+        'target_id'          => $spaceId,
+        'secret'             => 'test-secret',
+        'is_active'          => $active,
+        'health_status'      => $status,
+        'fail_count'         => $failCount,
+    ]);
+}

--- a/tests/Feature/RecoverWebhookCommandTest.php
+++ b/tests/Feature/RecoverWebhookCommandTest.php
@@ -249,6 +249,44 @@ test('command resets fail count on recovery', function () {
     expect($webhook->fail_count)->toBe(0);
 });
 
+test('command resets recovery-relative stats and clears last error on recovery', function () {
+    $webhook = createCommandTestWebhook([
+        'clickup_webhook_id'               => 'wh_123',
+        'health_status'                    => WebhookHealthStatus::FAILING,
+        'is_active'                        => false,
+        'fail_count'                       => 75,
+        'total_deliveries'                 => 1000,
+        'failed_deliveries'                => 400,
+        'deliveries_since_recovery'        => 120,
+        'failed_deliveries_since_recovery' => 90,
+        'recovery_count'                   => 2,
+        'last_error'                       => ['error' => 'boom', 'timestamp' => '2026-01-01T00:00:00+00:00'],
+    ]);
+
+    $response = mockCommandTestSuccessResponse();
+
+    $mock = Mockery::mock(Webhooks::class);
+    $mock->shouldReceive('update')
+        ->once()
+        ->with('wh_123', Mockery::any())
+        ->andReturn($response);
+
+    $this->instance(Webhooks::class, $mock);
+
+    $this->artisan('clickup:webhook-recover', ['webhook_id' => 'wh_123'])
+        ->assertExitCode(0);
+
+    $webhook->refresh();
+
+    expect($webhook->deliveries_since_recovery)->toBe(0)
+        ->and($webhook->failed_deliveries_since_recovery)->toBe(0)
+        ->and($webhook->recovery_count)->toBe(3)
+        ->and($webhook->recovered_at)->not->toBeNull()
+        ->and($webhook->last_error)->toBeNull()
+        ->and($webhook->total_deliveries)->toBe(1000)
+        ->and($webhook->failed_deliveries)->toBe(400);
+});
+
 test('command recovers all with mixed results', function () {
     // Log::spy();
 

--- a/tests/Feature/RecoverWebhookCommandTest.php
+++ b/tests/Feature/RecoverWebhookCommandTest.php
@@ -171,6 +171,51 @@ test('command handles exceptions gracefully', function () {
     expect($webhook->health_status)->toBe(WebhookHealthStatus::FAILING);
 });
 
+test('command recreates webhook deleted in clickup', function () {
+    config(['clickup-api.default_workspace_id' => 'ws_1']);
+
+    $webhook = createCommandTestWebhook([
+        'clickup_webhook_id' => 'wh_gone',
+        'health_status'      => WebhookHealthStatus::SUSPENDED,
+        'is_active'          => false,
+        'fail_count'         => 100,
+        'target_type'        => 'space',
+        'target_id'          => 's1',
+    ]);
+
+    $updateResponse = Mockery::mock(LazyResponseProxy::class);
+    $updateResponse->shouldReceive('status')->andReturn(404);
+    $updateResponse->shouldReceive('json')->andReturn(['err' => 'Webhook not found']);
+
+    $newWebhook = createCommandTestWebhook([
+        'clickup_webhook_id' => 'wh_new',
+        'target_type'        => 'space',
+        'target_id'          => 's1',
+    ]);
+
+    $mock = Mockery::mock(Webhooks::class);
+    $mock->shouldReceive('update')
+        ->once()
+        ->with('wh_gone', Mockery::any())
+        ->andReturn($updateResponse);
+    $mock->shouldReceive('createManaged')
+        ->once()
+        ->with('ws_1', Mockery::on(function ($data) {
+            return ($data['space_id'] ?? null) === 's1'
+                && is_array($data['events']);
+        }))
+        ->andReturn($newWebhook);
+
+    $this->instance(Webhooks::class, $mock);
+
+    $this->artisan('clickup:webhook-recover', ['webhook_id' => 'wh_gone'])
+        ->expectsOutput('  ✓ Recreated webhook (old wh_gone -> new wh_new)')
+        ->assertExitCode(0);
+
+    expect(ClickUpWebhook::where('clickup_webhook_id', 'wh_gone')->exists())->toBeFalse()
+        ->and(ClickUpWebhook::where('clickup_webhook_id', 'wh_gone')->withTrashed()->exists())->toBeTrue();
+});
+
 test('command resets fail count on recovery', function () {
     // Log::spy();
 

--- a/tests/Feature/WebhookControllerTest.php
+++ b/tests/Feature/WebhookControllerTest.php
@@ -111,6 +111,8 @@ test('webhook updates delivery counters', function () {
     $webhook->refresh();
     expect($webhook->total_deliveries)->toBe(2);
     expect($webhook->failed_deliveries)->toBe(0);
+    expect($webhook->deliveries_since_recovery)->toBe(2);
+    expect($webhook->failed_deliveries_since_recovery)->toBe(0);
 });
 
 test('webhook returns 404 for inactive webhook', function () {
@@ -156,6 +158,7 @@ test('webhook handles processing errors gracefully', function () {
     // Verify webhook failure was recorded
     $webhook->refresh();
     expect($webhook->failed_deliveries)->toBe(1);
+    expect($webhook->failed_deliveries_since_recovery)->toBe(1);
     expect($webhook->last_error)->not->toBeNull();
 });
 

--- a/tests/Unit/Jobs/CheckWebhookHealthTest.php
+++ b/tests/Unit/Jobs/CheckWebhookHealthTest.php
@@ -378,6 +378,70 @@ test('auto_restore disabled (default) does not call ensureManaged', function () 
     (new CheckWebhookHealth)->handle($webhooksEndpoint);
 });
 
+test('job marks recovery when clickup reactivates a failing webhook', function () {
+    $webhook = createHealthTestWebhook('wh_123', WebhookHealthStatus::FAILING);
+    $webhook->update([
+        'is_active'                        => false,
+        'fail_count'                       => 50,
+        'deliveries_since_recovery'        => 80,
+        'failed_deliveries_since_recovery' => 60,
+        'recovery_count'                   => 1,
+        'last_error'                       => ['error' => 'boom'],
+    ]);
+
+    $webhooksEndpoint = mockHealthTestWebhooksEndpoint([
+        [
+            'id'         => 'wh_123',
+            'status'     => 'active',
+            'fail_count' => 0,
+        ],
+    ]);
+
+    Log::shouldReceive('info')->times(3); // start + recovery + completion
+    Log::shouldReceive('debug')->once();
+    Log::shouldReceive('warning')->once(); // status change
+
+    $job = new CheckWebhookHealth;
+    $job->handle($webhooksEndpoint);
+
+    $webhook->refresh();
+    expect($webhook->health_status)->toBe(WebhookHealthStatus::ACTIVE)
+        ->and($webhook->is_active)->toBeTrue()
+        ->and($webhook->fail_count)->toBe(0)
+        ->and($webhook->deliveries_since_recovery)->toBe(0)
+        ->and($webhook->failed_deliveries_since_recovery)->toBe(0)
+        ->and($webhook->recovery_count)->toBe(2)
+        ->and($webhook->recovered_at)->not->toBeNull()
+        ->and($webhook->last_error)->toBeNull();
+});
+
+test('job does not mark recovery when webhook stays active', function () {
+    $webhook = createHealthTestWebhook('wh_123', WebhookHealthStatus::ACTIVE);
+    $webhook->update([
+        'deliveries_since_recovery' => 30,
+        'recovery_count'            => 1,
+    ]);
+
+    $webhooksEndpoint = mockHealthTestWebhooksEndpoint([
+        [
+            'id'         => 'wh_123',
+            'status'     => 'active',
+            'fail_count' => 0,
+        ],
+    ]);
+
+    Log::shouldReceive('info')->twice();
+    Log::shouldReceive('debug')->once();
+
+    $job = new CheckWebhookHealth;
+    $job->handle($webhooksEndpoint);
+
+    $webhook->refresh();
+    expect($webhook->recovery_count)->toBe(1)
+        ->and($webhook->deliveries_since_recovery)->toBe(30)
+        ->and($webhook->recovered_at)->toBeNull();
+});
+
 /**
  * Create a test webhook in the database.
  */

--- a/tests/Unit/Jobs/CheckWebhookHealthTest.php
+++ b/tests/Unit/Jobs/CheckWebhookHealthTest.php
@@ -311,6 +311,73 @@ test('job handles webhooks with missing fail count', function () {
     expect($webhook->fail_count)->toBe(0);
 });
 
+test('auto_restore re-asserts required events for each managed target', function () {
+    config([
+        'clickup-api.webhook.auto_restore'    => true,
+        'clickup-api.webhook.required_events' => ['taskCreated', 'taskDeleted'],
+    ]);
+
+    ClickUpWebhook::create([
+        'clickup_webhook_id' => 'wh_space',
+        'endpoint'           => 'https://app.test/webhooks/clickup',
+        'event'              => 'taskCreated',
+        'target_type'        => 'space',
+        'target_id'          => 's1',
+        'secret'             => 'test-secret',
+        'is_active'          => true,
+        'health_status'      => WebhookHealthStatus::ACTIVE,
+    ]);
+
+    $response = Mockery::mock(LazyResponseProxy::class);
+    $response->shouldReceive('status')->andReturn(200);
+    $response->shouldReceive('json')->andReturn(['webhooks' => []]);
+
+    $webhooksEndpoint = Mockery::mock(Webhooks::class);
+    $webhooksEndpoint->shouldReceive('index')->with('workspace_123')->once()->andReturn($response);
+    $webhooksEndpoint->shouldReceive('ensureManaged')
+        ->once()
+        ->with('workspace_123', Mockery::on(function ($desired) {
+            return is_array($desired)
+                && count($desired) === 2
+                && ($desired[0]['space_id'] ?? null) === 's1'
+                && in_array('taskCreated', $desired[0]['events'], true)
+                && in_array('taskDeleted', $desired[1]['events'], true);
+        }))
+        ->andReturn(collect());
+
+    Log::shouldReceive('info')->andReturnNull();
+    Log::shouldReceive('debug')->andReturnNull();
+    Log::shouldReceive('warning')->andReturnNull();
+
+    (new CheckWebhookHealth)->handle($webhooksEndpoint);
+});
+
+test('auto_restore disabled (default) does not call ensureManaged', function () {
+    ClickUpWebhook::create([
+        'clickup_webhook_id' => 'wh_space',
+        'endpoint'           => 'https://app.test/webhooks/clickup',
+        'event'              => 'taskCreated',
+        'target_type'        => 'space',
+        'target_id'          => 's1',
+        'secret'             => 'test-secret',
+        'is_active'          => true,
+        'health_status'      => WebhookHealthStatus::ACTIVE,
+    ]);
+
+    $response = Mockery::mock(LazyResponseProxy::class);
+    $response->shouldReceive('status')->andReturn(200);
+    $response->shouldReceive('json')->andReturn(['webhooks' => []]);
+
+    $webhooksEndpoint = Mockery::mock(Webhooks::class);
+    $webhooksEndpoint->shouldReceive('index')->with('workspace_123')->once()->andReturn($response);
+    $webhooksEndpoint->shouldReceive('ensureManaged')->never();
+
+    Log::shouldReceive('info')->andReturnNull();
+    Log::shouldReceive('debug')->andReturnNull();
+
+    (new CheckWebhookHealth)->handle($webhooksEndpoint);
+});
+
 /**
  * Create a test webhook in the database.
  */

--- a/tests/Unit/Jobs/ClickUpApiCallJobTest.php
+++ b/tests/Unit/Jobs/ClickUpApiCallJobTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Mindtwo\LaravelClickUpApi\Events\ClickUpApiCallCompleted;
+use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskUpdated;
+use Mindtwo\LaravelClickUpApi\Jobs\ClickUpApiCallJob;
+
+uses()->group('clickup-api-call-job');
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('dispatches success completion event and task event on 200', function () {
+    Event::fake([ClickUpApiCallCompleted::class, TaskUpdated::class]);
+    Http::fake(['*' => Http::response(['id' => 'abc'], 200)]);
+
+    (new ClickUpApiCallJob('/task/abc', 'PUT', ['name' => 'x']))->handle();
+
+    Event::assertDispatched(
+        ClickUpApiCallCompleted::class,
+        fn (ClickUpApiCallCompleted $event) => $event->successful === true && $event->statusCode === 200,
+    );
+    Event::assertDispatched(TaskUpdated::class);
+});
+
+test('emits failure event and does not throw on terminal 404', function () {
+    Event::fake([ClickUpApiCallCompleted::class]);
+    Http::fake(['*' => Http::response(['err' => 'Not found'], 404)]);
+
+    (new ClickUpApiCallJob('/task/gone', 'GET'))->handle();
+
+    Event::assertDispatched(
+        ClickUpApiCallCompleted::class,
+        fn (ClickUpApiCallCompleted $event) => $event->successful === false && $event->statusCode === 404,
+    );
+});
+
+test('emits failure event and does not throw on 429 rate limit', function () {
+    Event::fake([ClickUpApiCallCompleted::class]);
+    Http::fake(['*' => Http::response(['err' => 'Rate limit reached'], 429)]);
+
+    (new ClickUpApiCallJob('/task/abc', 'GET'))->handle();
+
+    Event::assertDispatched(
+        ClickUpApiCallCompleted::class,
+        fn (ClickUpApiCallCompleted $event) => $event->successful === false && $event->statusCode === 429,
+    );
+});
+
+test('does not dispatch task events on a failed response', function () {
+    Event::fake([ClickUpApiCallCompleted::class, TaskUpdated::class]);
+    Http::fake(['*' => Http::response(['err' => 'Bad request'], 400)]);
+
+    (new ClickUpApiCallJob('/task/abc', 'PUT', ['name' => 'x']))->handle();
+
+    Event::assertNotDispatched(TaskUpdated::class);
+});
+
+test('failed handler emits a failure completion event for no-response failures', function () {
+    Event::fake([ClickUpApiCallCompleted::class]);
+
+    (new ClickUpApiCallJob('/task/abc', 'GET'))->failed(new RuntimeException('Connection timed out'));
+
+    Event::assertDispatched(
+        ClickUpApiCallCompleted::class,
+        fn (ClickUpApiCallCompleted $event) => $event->successful === false && $event->statusCode === 0,
+    );
+});
+
+test('backoff is exponential', function () {
+    expect((new ClickUpApiCallJob('/task/abc', 'GET'))->backoff())->toBe([10, 30, 60, 120]);
+});

--- a/tests/Unit/Jobs/ClickUpApiCallJobTest.php
+++ b/tests/Unit/Jobs/ClickUpApiCallJobTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Mindtwo\LaravelClickUpApi\Events\ClickUpApiCallCompleted;
 use Mindtwo\LaravelClickUpApi\Events\Tasks\TaskUpdated;
+use Mindtwo\LaravelClickUpApi\Exceptions\ClickUpApiCallFailedException;
 use Mindtwo\LaravelClickUpApi\Jobs\ClickUpApiCallJob;
 
 uses()->group('clickup-api-call-job');
@@ -73,4 +74,38 @@ test('failed handler emits a failure completion event for no-response failures',
 
 test('backoff is exponential', function () {
     expect((new ClickUpApiCallJob('/task/abc', 'GET'))->backoff())->toBe([10, 30, 60, 120]);
+});
+
+test('failure exception exposes context and a descriptive message', function () {
+    $exception = new ClickUpApiCallFailedException('/task/x', 'PUT', 400, ['err' => 'Bad request']);
+
+    expect($exception->endpoint)->toBe('/task/x')
+        ->and($exception->method)->toBe('PUT')
+        ->and($exception->statusCode)->toBe(400)
+        ->and($exception->response)->toBe(['err' => 'Bad request'])
+        ->and($exception->getMessage())->toContain('400')
+        ->and($exception->getMessage())->toContain('Bad request');
+});
+
+test('failure exception is built from a response', function () {
+    Http::fake(['*' => Http::response(['err' => 'Not found'], 404)]);
+
+    $response = Http::get('https://example.test/task/gone');
+
+    $exception = ClickUpApiCallFailedException::fromResponse('/task/gone', 'GET', $response);
+
+    expect($exception->endpoint)->toBe('/task/gone')
+        ->and($exception->method)->toBe('GET')
+        ->and($exception->statusCode)->toBe(404)
+        ->and($exception->response)->toBe(['err' => 'Not found']);
+});
+
+test('failed handler does not re-dispatch for a terminal API failure exception', function () {
+    Event::fake([ClickUpApiCallCompleted::class]);
+
+    (new ClickUpApiCallJob('/task/x', 'GET'))->failed(
+        new ClickUpApiCallFailedException('/task/x', 'GET', 404, ['err' => 'Not found']),
+    );
+
+    Event::assertNotDispatched(ClickUpApiCallCompleted::class);
 });

--- a/tests/Unit/Models/ClickUpWebhookDeliveryTest.php
+++ b/tests/Unit/Models/ClickUpWebhookDeliveryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Mindtwo\LaravelClickUpApi\Models\ClickUpWebhookDelivery;
+
+uses()->group('clickup-webhook-delivery');
+
+beforeEach(function () {
+    foreach (File::allFiles(__DIR__.'/../../../database/migrations') as $migration) {
+        (include $migration->getRealPath())->up();
+    }
+});
+
+test('prunable targets deliveries older than the retention window', function () {
+    config(['clickup-api.deliveries.retention_days' => 30]);
+
+    $old = makeDelivery('old');
+    $old->created_at = now()->subDays(31);
+    $old->save();
+
+    $recent = makeDelivery('recent');
+    $recent->created_at = now()->subDays(5);
+    $recent->save();
+
+    $prunableIds = (new ClickUpWebhookDelivery)->prunable()->pluck('id');
+
+    expect($prunableIds)->toContain($old->id)
+        ->and($prunableIds)->not->toContain($recent->id);
+});
+
+test('retention window is configurable', function () {
+    config(['clickup-api.deliveries.retention_days' => 7]);
+
+    $delivery = makeDelivery('mid');
+    $delivery->created_at = now()->subDays(10);
+    $delivery->save();
+
+    expect((new ClickUpWebhookDelivery)->prunable()->pluck('id'))->toContain($delivery->id);
+});
+
+function makeDelivery(string $key): ClickUpWebhookDelivery
+{
+    return ClickUpWebhookDelivery::create([
+        'clickup_webhook_id' => 1,
+        'event'              => 'taskUpdated',
+        'payload'            => ['event' => 'taskUpdated'],
+        'status'             => 'processed',
+        'idempotency_key'    => $key,
+    ]);
+}

--- a/tests/Unit/Models/ClickUpWebhookTest.php
+++ b/tests/Unit/Models/ClickUpWebhookTest.php
@@ -64,25 +64,79 @@ test('webhook casts last error to array', function () {
 });
 
 test('record delivery increments counter and updates timestamp', function () {
-    $webhook = createModelTestWebhook(['total_deliveries' => 5]);
+    $webhook = createModelTestWebhook([
+        'total_deliveries'          => 5,
+        'deliveries_since_recovery' => 2,
+    ]);
 
     $webhook->recordDelivery();
 
     $webhook->refresh();
     expect($webhook->total_deliveries)->toBe(6);
+    expect($webhook->deliveries_since_recovery)->toBe(3);
     expect($webhook->last_triggered_at)->not->toBeNull();
 });
 
 test('record failure increments counter and stores error', function () {
-    $webhook = createModelTestWebhook(['failed_deliveries' => 2]);
+    $webhook = createModelTestWebhook([
+        'failed_deliveries'                => 2,
+        'failed_deliveries_since_recovery' => 1,
+    ]);
 
     $webhook->recordFailure('Test error message');
 
     $webhook->refresh();
     expect($webhook->failed_deliveries)->toBe(3);
+    expect($webhook->failed_deliveries_since_recovery)->toBe(2);
     expect($webhook->last_error)->toBeArray();
     expect($webhook->last_error['error'])->toBe('Test error message');
     expect($webhook->last_error)->toHaveKey('timestamp');
+});
+
+test('mark recovered restores health and resets recovery-relative stats', function () {
+    $webhook = createModelTestWebhook([
+        'health_status'                    => WebhookHealthStatus::SUSPENDED,
+        'is_active'                        => false,
+        'fail_count'                       => 100,
+        'total_deliveries'                 => 500,
+        'failed_deliveries'                => 300,
+        'deliveries_since_recovery'        => 120,
+        'failed_deliveries_since_recovery' => 100,
+        'recovery_count'                   => 3,
+        'last_error'                       => ['error' => 'boom'],
+    ]);
+
+    $webhook->markRecovered();
+
+    $webhook->refresh();
+    expect($webhook->health_status)->toBe(WebhookHealthStatus::ACTIVE)
+        ->and($webhook->is_active)->toBeTrue()
+        ->and($webhook->fail_count)->toBe(0)
+        ->and($webhook->deliveries_since_recovery)->toBe(0)
+        ->and($webhook->failed_deliveries_since_recovery)->toBe(0)
+        ->and($webhook->recovery_count)->toBe(4)
+        ->and($webhook->recovered_at)->not->toBeNull()
+        ->and($webhook->last_error)->toBeNull()
+        ->and($webhook->total_deliveries)->toBe(500)
+        ->and($webhook->failed_deliveries)->toBe(300);
+});
+
+test('failure rate since recovery calculates correctly', function () {
+    $webhook = createModelTestWebhook([
+        'deliveries_since_recovery'        => 50,
+        'failed_deliveries_since_recovery' => 10,
+    ]);
+
+    expect($webhook->failure_rate_since_recovery)->toBe(20.0);
+});
+
+test('failure rate since recovery returns zero for no deliveries', function () {
+    $webhook = createModelTestWebhook([
+        'deliveries_since_recovery'        => 0,
+        'failed_deliveries_since_recovery' => 0,
+    ]);
+
+    expect($webhook->failure_rate_since_recovery)->toBe(0.0);
 });
 
 test('failure rate attribute calculates correctly', function () {


### PR DESCRIPTION
## Self-healing ClickUp webhook registration & recovery

### Why
Webhooks can be auto-suspended by ClickUp after repeated delivery failures or can be falsly deleted. Once that happens the package stops receiving the affected events and has
no mechanism to detect a *missing* required webhook or to recreate one that no longer exists
remotely — leaving consumers silently blind to those events.

### Changes
- **`Webhooks::ensureManaged(workspaceId, desired)`** — a reconcile primitive that brings the
  registered webhooks in line with a desired set (endpoint + events per target):
  - creates any webhook that is missing,
  - reactivates ones that are present but inactive,
  - recreates ones that ClickUp returns `404` for (deleted upstream).
- **`RecoverWebhookCommand`** — when reactivating via `update()` returns `404` (webhook gone
  upstream), fall back to recreating it instead of failing.
- *(optional)* **`clickup-api.webhook.required_events`** config default so callers have a
  sensible baseline event set.

The desired set is supplied by the caller (it owns its targets/endpoint), keeping the
mechanism generic and reusable.

### Tests
Added/extended coverage for `Webhooks` reconciliation and `RecoverWebhookCommand`
recreate-on-404; existing `WebhookController` / `CheckWebhookHealth` suites still pass.